### PR TITLE
Tighten lower bound on `base`

### DIFF
--- a/microlens-aeson.cabal
+++ b/microlens-aeson.cabal
@@ -35,7 +35,7 @@ library
   build-depends:
                   aeson                >= 0.7.0.5   && < 1.2
                 , attoparsec           >= 0.10      && < 0.14
-                , base                 >= 4.5       && < 5
+                , base                 >= 4.8       && < 5
                 , bytestring           >= 0.9       && < 0.11
                 , microlens            >= 0.3       && < 0.5
                 , scientific           >= 0.3.2     && < 0.4


### PR DESCRIPTION
As otherwise with a pre-AMP `base` compile failures like below occur

```
Configuring component lib from microlens-aeson-2.1.1.2...
Warning: To use the 'default-language' field the package needs to specify at least 'cabal-version: >= 1.10'.
Preprocessing library microlens-aeson-2.1.1.2...
[1 of 2] Compiling Lens.Micro.Aeson.Internal ( src/Lens/Micro/Aeson/Internal.hs, /tmp/matrix-worker/1483376984/dist-newstyle/build/x86_64-linux/ghc-7.8.4/microlens-aeson-2.1.1.2/build/Lens/Micro/Aeson/Internal.o )

src/Lens/Micro/Aeson/Internal.hs:33:30: Not in scope: ‘<$>’

src/Lens/Micro/Aeson/Internal.hs:34:23: Not in scope: ‘pure’

src/Lens/Micro/Aeson/Internal.hs:44:47: Not in scope: ‘<$>’

src/Lens/Micro/Aeson/Internal.hs:45:16: Not in scope: ‘pure’

src/Lens/Micro/Aeson/Internal.hs:55:58: Not in scope: ‘<$>’

src/Lens/Micro/Aeson/Internal.hs:56:19: Not in scope: ‘pure’
```