### PR TITLE
missing atKey function from lens-aeson package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ wip
 *~
 *#
 .stack-work/*
+dist-newstyle/*

--- a/src/Lens/Micro/Aeson.hs
+++ b/src/Lens/Micro/Aeson.hs
@@ -23,7 +23,7 @@ module Lens.Micro.Aeson
   , nonNull
   -- * Objects and Arrays
   , AsValue(..)
-  , key, members
+  , key, atKey, members
   , nth, values
   -- * Decoding
   , AsJSON(..)
@@ -235,6 +235,21 @@ instance AsValue LazyText.Text where
 key :: AsValue t => Key -> Traversal' t Value
 key i = _Object . ix i
 {-# INLINE key #-}
+
+-- |
+-- Like 'key', but uses 'at' instead of 'ix'. This is handy when
+-- adding and removing object keys:
+--
+-- >>> "{\"a\": 100, \"b\": 200}" & atKey "a" .~ Nothing
+-- "{\"b\":200}"
+--
+-- >>> "{\"a\": 100, \"b\": 200}" & atKey "c" ?~ String "300"
+-- "{\"a\":100,\"b\":200,\"c\":\"300\"}"
+
+-- @since 2.5.3
+atKey :: AsValue t => Key -> Traversal' t (Maybe Value)
+atKey i = _Object . at i
+{-# INLINE atKey #-}
 
 -- | A Traversal into Object properties
 --


### PR DESCRIPTION
@fosskers 
I don't know if this was an oversight, but I believe this would more or less complete the functionality provided by lens-aeson package
Please have a look.